### PR TITLE
Add settings for cross-releasing 2.11.x and 2.12.x versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: scala
 sudo: false
 
 scala:
+- 2.11.11
 - 2.12.2
 
 jdk:

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -9,6 +9,7 @@ object Build extends Build {
   lazy val basicSettings = Seq(
     organization := "com.xebia",
     scalaVersion := "2.12.2",
+    crossScalaVersions := Seq("2.11.11", "2.12.2"),
     scalacOptions := basicScalacOptions,
     incOptions := incOptions.value.withNameHashing(true),
     licenses := Seq("The MIT License (MIT)" -> url("http://opensource.org/licenses/MIT"))

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -7,6 +7,7 @@ import com.typesafe.sbt.pgp._
 
 object Publishing {
   lazy val publishingSettings = sonatypeSettings ++ Seq(
+    releaseCrossBuild := true,
     releasePublishArtifactsAction := PgpKeys.publishSigned.value,
     publishTo := {
       val nexus = "https://oss.sonatype.org/"


### PR DESCRIPTION
for those of us still on Scala 2.11.x 