### PR TITLE
Make GlobalExecutionContextProvider extend ExecutionContextProvider

### DIFF
--- a/src/main/scala/cakemix/ExecutionContextProvider.scala
+++ b/src/main/scala/cakemix/ExecutionContextProvider.scala
@@ -45,6 +45,6 @@ trait ActorExecutionContextProvider extends ExecutionContextProvider { this: Act
  * Implementation of [[cakemix.ExecutionContextProvider]] that uses the
  * ExecutionContext provided by scala.concurrent.ExecutionContext.global.
  */
-trait GlobalExecutionContextProvider {
+trait GlobalExecutionContextProvider extends ExecutionContextProvider {
   implicit def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.global
 }


### PR DESCRIPTION
This is already mentioned in the scaladoc, but i guess it was omitted in the code.