### PR TITLE
Update akka-actor to 2.8.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val commonSettings = Seq(
 
 lazy val typesafeConfig = "com.typesafe" % "config" % "1.4.6" % Provided
 
-lazy val akkaActor = "com.typesafe.akka" %% "akka-actor" % "2.7.0" % Provided
+lazy val akkaActor = "com.typesafe.akka" %% "akka-actor" % "2.8.0" % Provided
 
 lazy val pekkoActor = "org.apache.pekko" %% "pekko-actor" % "1.4.0" % Provided
 


### PR DESCRIPTION
Akka 2.8.0 is now Apache 2.0.